### PR TITLE
Backoffice moderator : organisation management

### DIFF
--- a/backend/routes/backoffice/login.js
+++ b/backend/routes/backoffice/login.js
@@ -25,6 +25,7 @@ module.exports = function(db, authService, logger, configuration) {
             profile: 'moderateur',
             id: moderator._id,
             codeRegion: moderator.codeRegion,
+            features: moderator.features
         });
         return res.status(200).send(token);
     };

--- a/backend/routes/backoffice/organisations.js
+++ b/backend/routes/backoffice/organisations.js
@@ -419,5 +419,24 @@ module.exports = function (db, authService, logger, configuration) {
         }
     });
 
+    router.post('/backoffice/organisation/:id/editedEmail', tryAndCatch(async (req, res) => {
+        const email = req.body.email;
+        const id = parseInt(req.params.id);
+
+        if (isNaN(id)) {
+            throw Boom.notFound('Not found');
+        }
+
+        let organisme = await db.collection('organismes').findOne({ _id: id });
+        if (organisme) {
+            if (!organisme.passwordHash) {
+                await db.collection('organismes').update({ _id: id }, { $set: { editedEmail: email } });
+                res.status(201).send('OK');
+            }
+        } else {
+            throw Boom.notFound('Not found');
+        }
+    }));
+
     return router;
 };

--- a/backend/routes/backoffice/organisations.js
+++ b/backend/routes/backoffice/organisations.js
@@ -430,7 +430,7 @@ module.exports = (db, authService, logger, configuration) => {
         }
     });
 
-    router.post('/backoffice/organisation/:id/editedEmail', tryAndCatch(async (req, res) => {
+    router.post('/backoffice/organisation/:id/editedEmail', checkAuth, async (req, res) => {
         const email = req.body.email;
         const id = parseInt(req.params.id);
 
@@ -453,7 +453,7 @@ module.exports = (db, authService, logger, configuration) => {
         } else {
             throw Boom.notFound('Not found');
         }
-    }));
+    });
 
     router.get('/backoffice/organisation/:id/editedEmail/delete', checkAuth, async (req, res) => {
         const id = parseInt(req.params.id);

--- a/backend/routes/backoffice/organisations.js
+++ b/backend/routes/backoffice/organisations.js
@@ -430,12 +430,12 @@ module.exports = (db, authService, logger, configuration) => {
         }
     });
 
-    router.post('/backoffice/organisation/:id/editedEmail', checkAuth, async (req, res) => {
+    router.post('/backoffice/organisation/:id/editedEmail', checkAuth, tryAndCatch(async (req, res) => {
         const email = req.body.email;
         const id = parseInt(req.params.id);
 
         if (isNaN(id)) {
-            throw Boom.notFound('Not found');
+            throw Boom.badRequest('Bad request');
         }
 
         let organisme = await db.collection('organismes').findOne({ _id: id });
@@ -453,13 +453,13 @@ module.exports = (db, authService, logger, configuration) => {
         } else {
             throw Boom.notFound('Not found');
         }
-    });
+    }));
 
-    router.get('/backoffice/organisation/:id/editedEmail/delete', checkAuth, async (req, res) => {
+    router.get('/backoffice/organisation/:id/editedEmail/delete', checkAuth, tryAndCatch(async (req, res) => {
         const id = parseInt(req.params.id);
 
         if (isNaN(id)) {
-            throw Boom.notFound('Not found');
+            throw Boom.badRequest('Bad request');
         }
 
         let organisme = await db.collection('organismes').findOne({ _id: id });
@@ -477,15 +477,15 @@ module.exports = (db, authService, logger, configuration) => {
         } else {
             throw Boom.notFound('Not found');
         }
-    });
+    }));
 
-    router.post('/backoffice/organisation/:id/resendEmailAccount', checkAuth, async (req, res) => {
+    router.post('/backoffice/organisation/:id/resendEmailAccount', checkAuth, tryAndCatch(async (req, res) => {
         const id = parseInt(req.params.id);
 
         const organismes = db.collection('organismes');
 
         if (isNaN(id)) {
-            throw Boom.notFound('Not found');
+            throw Boom.badRequest('Bad request');
         }
 
         let organisme = await organismes.findOne({ _id: id });
@@ -512,7 +512,7 @@ module.exports = (db, authService, logger, configuration) => {
         } else {
             throw Boom.notFound('Not found');
         }
-    });
+    }));
 
     return router;
 };

--- a/backend/routes/backoffice/organisations.js
+++ b/backend/routes/backoffice/organisations.js
@@ -438,5 +438,23 @@ module.exports = function (db, authService, logger, configuration) {
         }
     }));
 
+    router.get('/backoffice/organisation/:id/editedEmail/delete', tryAndCatch(async (req, res) => {
+        const id = parseInt(req.params.id);
+
+        if (isNaN(id)) {
+            throw Boom.notFound('Not found');
+        }
+
+        let organisme = await db.collection('organismes').findOne({ _id: id });
+        if (organisme) {
+            if (!organisme.passwordHash) {
+                await db.collection('organismes').update({ _id: id }, { $unset: { editedEmail: '' } });
+                res.status(200).send({ 'status': 'OK' });
+            }
+        } else {
+            throw Boom.notFound('Not found');
+        }
+    }));
+
     return router;
 };

--- a/backend/routes/backoffice/organisations.js
+++ b/backend/routes/backoffice/organisations.js
@@ -431,7 +431,7 @@ module.exports = function (db, authService, logger, configuration) {
         if (organisme) {
             if (!organisme.passwordHash) {
                 await db.collection('organismes').update({ _id: id }, { $set: { editedEmail: email } });
-                res.status(201).send('OK');
+                res.status(201).send({ 'status': 'OK' });
             }
         } else {
             throw Boom.notFound('Not found');

--- a/backoffice/package-lock.json
+++ b/backoffice/package-lock.json
@@ -5689,11 +5689,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -5706,15 +5708,18 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -5817,7 +5822,8 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -5827,6 +5833,7 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5839,17 +5846,20 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -5866,6 +5876,7 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -5938,7 +5949,8 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5948,6 +5960,7 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -6053,6 +6066,7 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/backoffice/package.json
+++ b/backoffice/package.json
@@ -44,7 +44,7 @@
     "eslint": "5.6.0",
     "eslint-plugin-react": "7.11.1"
   },
-  "proxy": "http://anotea.local:8080/",
+  "proxy": "http://localhost:8080/",
   "browserslist": [
     ">0.2%",
     "not dead",

--- a/backoffice/package.json
+++ b/backoffice/package.json
@@ -44,7 +44,7 @@
     "eslint": "5.6.0",
     "eslint-plugin-react": "7.11.1"
   },
-  "proxy": "http://localhost:8080/",
+  "proxy": "http://anotea.local:8080/",
   "browserslist": [
     ">0.2%",
     "not dead",

--- a/backoffice/src/App.js
+++ b/backoffice/src/App.js
@@ -45,7 +45,8 @@ class App extends Component {
                 codeRegion: sessionStorage.userCodeRegion,
                 codeFinanceur: sessionStorage.userCodeFinanceur,
                 raisonSociale: sessionStorage.userRaisonSociale,
-                action: null
+                action: null,
+                features: sessionStorage.features
             };
         }
         const qs = queryString.parse(window.location.search);

--- a/backoffice/src/App.js
+++ b/backoffice/src/App.js
@@ -86,13 +86,14 @@ class App extends Component {
 
     handleLoggedIn = result => {
 
-        let { profile, id, codeRegion, codeFinanceur, raisonSociale } = jwtDecode(result.access_token);
+        let { profile, id, codeRegion, codeFinanceur, raisonSociale, features } = jwtDecode(result.access_token);
 
         sessionStorage.userId = id;
         sessionStorage.userProfile = profile;
         sessionStorage.userCodeRegion = codeRegion;
         sessionStorage.userCodeFinanceur = codeFinanceur;
         sessionStorage.userRaisonSociale = raisonSociale;
+        sessionStorage.features = features;
         setToken(result.access_token);
 
         this.setState({
@@ -102,14 +103,15 @@ class App extends Component {
             id,
             codeRegion: codeRegion,
             codeFinanceur: codeFinanceur,
-            raisonSociale: raisonSociale
+            raisonSociale: raisonSociale,
+            features: features
         });
 
         getRegion(this.state.codeRegion).then(region => {
             this.setState({
                 region: region.region
             });
-        })
+        });
     };
 
     handleError = () => {
@@ -151,7 +153,7 @@ class App extends Component {
                         handleLoggedIn={this.handleLoggedIn} />}
                     {showDashboard &&
                     <Main profile={this.state.profile} id={this.state.id} codeRegion={this.state.codeRegion}
-                        codeFinanceur={this.state.codeFinanceur} />}
+                        codeFinanceur={this.state.codeFinanceur} features={this.state.features} />}
 
                 </div>
             </IntlProvider>

--- a/backoffice/src/App.js
+++ b/backoffice/src/App.js
@@ -14,6 +14,8 @@ import { setToken, removeToken }            from './utils/token';
 import { subscribeToHttpEvent }             from './utils/http-client';
 import { getRegion }                        from './lib/financerService';
 
+import './utils/moment-fr';
+
 addLocaleData([...fr]);
 
 class App extends Component {

--- a/backoffice/src/components/backoffice/Main.js
+++ b/backoffice/src/components/backoffice/Main.js
@@ -1,12 +1,22 @@
 import React from 'react';
 
-import ModerationPanel from './moderation/ModerationPanel';
+import PropTypes from 'prop-types';
+
+import ModerationMain from './moderation/ModerationMain';
 import OrganisationPanel from './organisation/OrganisationPanel';
 import FinancerPanel from './financer/FinancerPanel';
 
 export class Main extends React.Component {
 
     state = {}
+
+    propTypes = {
+        id: PropTypes.string.isRequired,
+        codeRegion: PropTypes.string.isRequired,
+        profile: PropTypes.string.isRequired,
+        codeFinanceur: PropTypes.string.isRequired,
+        raisonSociale: PropTypes.string.isRequired
+    }
 
     constructor(props) {
         super(props);
@@ -23,7 +33,7 @@ export class Main extends React.Component {
         return (
             <div className="main">
                 {this.state.profile === 'moderateur' &&
-                <ModerationPanel
+                <ModerationMain
                     id={this.state.id}
                     codeRegion={this.state.codeRegion} />
                 }

--- a/backoffice/src/components/backoffice/Main.js
+++ b/backoffice/src/components/backoffice/Main.js
@@ -15,7 +15,8 @@ export class Main extends React.Component {
         codeRegion: PropTypes.string.isRequired,
         profile: PropTypes.string.isRequired,
         codeFinanceur: PropTypes.string.isRequired,
-        raisonSociale: PropTypes.string.isRequired
+        raisonSociale: PropTypes.string.isRequired,
+        features: PropTypes.array.isRequired
     }
 
     constructor(props) {
@@ -25,7 +26,8 @@ export class Main extends React.Component {
             id: props.id,
             codeRegion: props.codeRegion,
             codeFinanceur: props.codeFinanceur,
-            raisonSociale: props.raisonSociale
+            raisonSociale: props.raisonSociale,
+            features: props.features
         };
     }
 
@@ -35,19 +37,22 @@ export class Main extends React.Component {
                 {this.state.profile === 'moderateur' &&
                 <ModerationMain
                     id={this.state.id}
-                    codeRegion={this.state.codeRegion} />
+                    codeRegion={this.state.codeRegion}
+                    features={this.state.features} />
                 }
                 {this.state.profile === 'organisme' &&
                 <OrganisationPanel
                     id={this.state.id}
-                    raisonSociale={this.state.raisonSociale} />
+                    raisonSociale={this.state.raisonSociale}
+                    features={this.state.features} />
                 }
                 {this.state.profile === 'financer' &&
                 <FinancerPanel
                     profile={this.state.profile}
                     id={this.state.id}
                     codeRegion={this.state.codeRegion}
-                    codeFinanceur={this.state.codeFinanceur} />
+                    codeFinanceur={this.state.codeFinanceur}
+                    features={this.state.features} />
                 }
             </div>
         );

--- a/backoffice/src/components/backoffice/moderation/Email.js
+++ b/backoffice/src/components/backoffice/moderation/Email.js
@@ -72,18 +72,18 @@ export default class Email extends React.Component {
                         <i className="icon glyphicon glyphicon-ok" /> <span>{this.props.label}</span> <a href={`mailto:${this.props.current}`}>{this.state.current}</a>
 
                         {this.state.active && this.props.editButton &&
-                            <button className="btn btn-primary" onClick={this.changeMode.bind(this, 'edit')}>Modifier</button>
+                            <button className="btn btn-primary" onClick={this.changeMode.bind(this, 'edit')}><i className="glyphicon glyphicon-pencil" /> Modifier</button>
                         }
 
                         {this.props.deleteEditedEmail &&
-                            <button className="btn btn-danger" onClick={this.delete}>Supprimer</button>
+                            <button className="btn btn-danger" onClick={this.delete}><i className="glyphicon glyphicon-remove-sign" /> Supprimer</button>
                         }
                     </div>
                 }
 
                 {this.state.mode === 'edit' &&
                     <div className="edit">
-                        Anotea : <input type="text" value={this.state.editedEmail} onChange={this.handleEmailChange} /> <button className="btn btn-primary" onClick={this.update}>Mettre à jour</button> <button className="btn" onClick={this.cancel}>Annuler</button>
+                        Anotea : <input type="text" value={this.state.editedEmail} onChange={this.handleEmailChange} /> <button className="btn btn-primary" onClick={this.update}> <i className="glyphicon glyphicon-ok-sign"></i> Mettre à jour</button> <button className="btn" onClick={this.cancel}>Annuler</button>
                     </div>
                 }
             </div>

--- a/backoffice/src/components/backoffice/moderation/Email.js
+++ b/backoffice/src/components/backoffice/moderation/Email.js
@@ -1,0 +1,70 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import './email.css';
+
+import { updateEditedEmail } from '../../../lib/organisationService';
+
+export default class Email extends React.Component {
+
+    state = {
+        active: false,
+        mode: 'view',
+        emailEdited: ''
+    }
+
+    static propTypes = {
+        current: PropTypes.any.isRequired,
+        active: PropTypes.any.isRequired,
+        label: PropTypes.string.isRequired,
+        organisationId: PropTypes.number.isRequired
+    }
+
+    constructor(props) {
+        super(props);
+        this.state.active = props.current === this.props.active;
+        this.state.current = props.current;
+    }
+
+    changeMode = mode => {
+        this.setState({ mode: mode });
+    }
+
+    cancel = () => {
+        this.setState({ emailEdited: '' });
+        this.changeMode('view');
+    }
+
+    update = () => {
+        updateEditedEmail(this.props.organisationId, this.state.emailEdited).then(() => {
+            this.changeMode('view');
+            this.setState({ current: this.state.emailEdited });
+        });
+    }
+
+    handleEmailChange = event => {
+        this.setState({ emailEdited: event.target.value });
+    }
+
+    render() {
+        return (
+            <div className={`email ${this.state.active ? 'active' : 'not-current'}`}>
+                {this.state.mode === 'view' &&
+                    <div>
+                        <i className="icon glyphicon glyphicon-ok" /> <span>{this.props.label}</span> <a href="mailto:this.props.current">{this.state.current}</a>
+
+                        {this.state.active &&
+                            <button className="btn btn-primary" onClick={this.changeMode.bind(this, 'edit')}>Modifier</button>
+                        }
+                    </div>
+                }
+
+                {this.state.mode === 'edit' &&
+                    <div>
+                        Anotea : <input type="text" value={this.state.editedEmail} onChange={this.handleEmailChange} /> <button className="btn btn-primary" onClick={this.update}>Mettre à jour</button> <button className="btn" onClick={this.cancel}>Annuler</button>
+                    </div>
+                }
+            </div>
+        );
+    }
+}

--- a/backoffice/src/components/backoffice/moderation/ModerationMain.js
+++ b/backoffice/src/components/backoffice/moderation/ModerationMain.js
@@ -1,0 +1,39 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import SideMenu from './SideMenu';
+import ModerationPanel from './ModerationPanel';
+import OrganisationPanel from './OrganisationPanel';
+
+export default class Main extends React.Component {
+
+    state = {
+        currentPage: 'moderation'
+    }
+
+    propTypes = {
+        id: PropTypes.string.isRequired,
+        codeRegion: PropTypes.string.isRequired,
+    }
+
+    handleChangePage = page => {
+        this.setState({ currentPage: page });
+    }
+
+    render() {
+        return (
+            <div className="mainPanel">
+                <SideMenu onChangePage={this.handleChangePage} />
+
+                {this.state.currentPage === 'moderation' &&
+                <ModerationPanel
+                    id={this.props.id}
+                    codeRegion={this.props.codeRegion} />}
+
+                {this.state.currentPage === 'organisme' &&
+                <OrganisationPanel
+                    codeRegion={this.props.codeRegion} />}
+            </div>
+        );
+    }
+}

--- a/backoffice/src/components/backoffice/moderation/ModerationMain.js
+++ b/backoffice/src/components/backoffice/moderation/ModerationMain.js
@@ -5,7 +5,7 @@ import SideMenu from './SideMenu';
 import ModerationPanel from './ModerationPanel';
 import OrganisationPanel from './OrganisationPanel';
 
-export default class Main extends React.Component {
+export default class ModerationMain extends React.Component {
 
     state = {
         currentPage: 'moderation'

--- a/backoffice/src/components/backoffice/moderation/ModerationMain.js
+++ b/backoffice/src/components/backoffice/moderation/ModerationMain.js
@@ -14,6 +14,7 @@ export default class ModerationMain extends React.Component {
     propTypes = {
         id: PropTypes.string.isRequired,
         codeRegion: PropTypes.string.isRequired,
+        features: PropTypes.array.isRequired
     }
 
     handleChangePage = page => {
@@ -23,7 +24,7 @@ export default class ModerationMain extends React.Component {
     render() {
         return (
             <div className="mainPanel">
-                <SideMenu onChangePage={this.handleChangePage} />
+                <SideMenu onChangePage={this.handleChangePage} features={this.props.features} />
 
                 {this.state.currentPage === 'moderation' &&
                 <ModerationPanel

--- a/backoffice/src/components/backoffice/moderation/ModerationPanel.js
+++ b/backoffice/src/components/backoffice/moderation/ModerationPanel.js
@@ -193,7 +193,7 @@ export default class ModerationPanel extends React.Component {
 
     render() {
         return (
-            <div className="moderationPanel mainPanel">
+            <div className="moderationPanel">
                 <h1>Panneau de modération</h1>
 
                 <h2>Liste des avis</h2>

--- a/backoffice/src/components/backoffice/moderation/OrganisationDetail.js
+++ b/backoffice/src/components/backoffice/moderation/OrganisationDetail.js
@@ -27,6 +27,8 @@ export default class OrganisationDetail extends React.PureComponent {
         email: null,
         editedEmail: null,
         anoteaEmailmode: 'view',
+        resendDisabled: false,
+        lastResend: null
     }
 
     static propTypes = {
@@ -71,6 +73,10 @@ export default class OrganisationDetail extends React.PureComponent {
     resend = () => {
         resendEmailAccount(this.state.organisation._id).then(() => {
             this.props.refresh();
+            this.setState({ resendDisabled: true, lastResend: new Date() });
+            setTimeout(() => {
+                this.setState({ resendDisabled: false });
+            }, 60000);
         });
     }
 
@@ -89,12 +95,9 @@ export default class OrganisationDetail extends React.PureComponent {
 
                         <OrganisationInfo organisation={this.state.organisation} />
 
-                        Actions :
-                        <ul>
-                            <li><button onClick={this.resend}>Renvoyer le lien de connexion</button></li>
-                        </ul>
+                        <button id="btnResend" className="btn btn-info" disabled={this.state.resendDisabled} onClick={this.resend}><i className="glyphicon glyphicon-send"/> Renvoyer le lien de connexion</button>
 
-                        <strong>Modifier l'adresse d'un Organisme de Formation</strong>
+                        <h5>Modifier l'adresse d'un Organisme de Formation</h5>
                         <div>
                             { (this.state.editedEmail || this.state.anoteaEmailmode) &&
                                 <Email label="Anotea" current={this.state.editedEmail} active={this.state.email} organisationId={this.state.organisation._id} deleteEditedEmail={this.deleteEditedEmail} updateEditedEmail={this.updateEditedEmail} mode={this.state.anoteaEmailmode} changeMode={this.changeMode} editButton={true} />

--- a/backoffice/src/components/backoffice/moderation/OrganisationDetail.js
+++ b/backoffice/src/components/backoffice/moderation/OrganisationDetail.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import './sideMenu.css';
+import './organisationDetail.css';
 
 import Email from './Email';
 
@@ -38,23 +38,28 @@ export default class OrganisationDetail extends React.PureComponent {
 
     constructor(props) {
         super(props);
-        if (props.organisation) {
+        if (props.organisation !== undefined) {
             this.state.organisation = props.organisation;
-            this.state.editedEmail = props.organisation.editedEmail;
-            this.state.email = this.getEmail();
+            if (props.organisation !== null) {
+                this.state.editedEmail = props.organisation.editedEmail;
+                this.state.email = this.getEmail();
+            }
         }
     }
 
     componentWillReceiveProps(nextProps) {
         this.props = nextProps;
-        if (nextProps.organisation) {
-            this.setState({
-                editedEmail: nextProps.organisation.editedEmail,
-                organisation: nextProps.organisation
-            },
-            () => this.setState({
-                email: this.getEmail()
-            }));
+        if (nextProps.organisation !== undefined) {
+            this.setState({ organisation: nextProps.organisation });
+            if (nextProps.organisation !== null) {
+                this.setState({
+                    editedEmail: nextProps.organisation.editedEmail,
+                    organisation: nextProps.organisation
+                },
+                () => this.setState({
+                    email: this.getEmail()
+                }));
+            }
         }
     }
 
@@ -84,8 +89,8 @@ export default class OrganisationDetail extends React.PureComponent {
         return (
             <div className="organisationDetail">
                 {this.state.organisation === null &&
-                    <div >
-                        <span className="alert alert-danger">Organisme introuvable</span>
+                    <div className="not-found">
+                        <span className="alert-not-found alert alert-danger">Organisme introuvable</span>
                     </div>
                 }
                 {this.state.organisation &&

--- a/backoffice/src/components/backoffice/moderation/OrganisationDetail.js
+++ b/backoffice/src/components/backoffice/moderation/OrganisationDetail.js
@@ -1,0 +1,79 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import './sideMenu.css';
+
+export default class OrganisationDetail extends React.PureComponent {
+
+    state = {
+        mode: 'view',
+        emailEdited: ''
+    }
+
+    propTypes = {
+        organisation: PropTypes.object.isRequired,
+    }
+
+    componentWillReceiveProps = async nextProps => {
+        console.log(nextProps)
+    }
+
+    getEmail = () => {
+        let email = this.props.organisation.courriel;
+        try {
+            email = this.props.organisation.meta.kairosData.emailRGC;
+        } catch (e) {
+
+        }
+        email = this.props.organisation.editedEmail !== undefined ? this.props.organisation.editedEmail : email;
+
+        return email;
+    }
+
+    changeMode = mode => {
+        this.setState({mode : mode});
+    }
+
+    cancel = () => {
+        this.setState({ emailEdited: '' });
+        this.changeMode('view');
+    }
+
+    update = () => {
+        // TODO : save
+        this.setState({ emailEdited: '' });
+        this.changeMode('view');
+    }
+
+    render() {
+        return (
+            <div className="organisationDetail">
+                {this.props.organisation === null &&
+                    <div >
+                        <span className="alert alert-danger">Organisme introuvable</span>
+                    </div>
+                }
+                {this.props.organisation &&
+                    <div>
+                        <h3>{this.props.organisation.raisonSociale}</h3>
+                        <h4>SIRET {this.props.organisation._id}</h4>
+                        <strong>Modifier l'adresse d'un Organisme de Formation</strong>
+                        <div>
+                            Adresse email Anotea : 
+                            {this.state.mode === 'view' &&
+                                <div>
+                                    <span>{this.getEmail()}</span> <button className="btn btn-primary" onClick={this.changeMode.bind(this, 'edit')}>Modifier</button>
+                                </div>
+                            }
+                            {this.state.mode === 'edit' &&
+                                <div>
+                                    <input type="text" /> <button className="btn btn-primary" onClick={this.update}>Mettre à jour</button> <button className="btn" onClick={this.cancel}>Annuler</button>
+                                </div>
+                            }
+                        </div>
+                    </div>
+                }
+            </div>
+        );
+    }
+}

--- a/backoffice/src/components/backoffice/moderation/OrganisationDetail.js
+++ b/backoffice/src/components/backoffice/moderation/OrganisationDetail.js
@@ -16,13 +16,46 @@ export default class OrganisationDetail extends React.PureComponent {
         } catch (e) {
 
         }
-        email = this.props.organisation.editedEmail !== undefined ? this.props.organisation.editedEmail : email;
+        email = this.state.editedEmail !== undefined ? this.state.editedEmail : email;
 
         return email;
     }
 
+    state = {
+        email: null,
+        editedEmail: null,
+        anoteaEmailmode: 'view'
+    }
+
     static propTypes = {
         organisation: PropTypes.object
+    }
+
+    constructor(props) {
+        super(props);
+        if (props.organisation) {
+            this.state.editedEmail = props.organisation.editedEmail;
+            this.state.email = this.getEmail();
+        }
+    }
+
+    componentWillReceiveProps(nextProps) {
+        this.props = nextProps;
+        if (nextProps.organisation) {
+            this.setState({ editedEmail: nextProps.organisation.editedEmail }, () => this.setState({ email: this.getEmail() }));
+        }
+    }
+
+    deleteEditedEmail = () => {
+        this.setState({ editedEmail: undefined }, () => this.setState({ email: this.getEmail() }));
+    }
+
+    updateEditedEmail = email => {
+        this.setState({ editedEmail: email }, () => this.setState({ email: this.getEmail() }));
+    }
+
+    changeMode = mode => {
+        this.setState({ anoteaEmailmode: mode });
     }
 
     render() {
@@ -39,13 +72,13 @@ export default class OrganisationDetail extends React.PureComponent {
                         <h4>SIRET {this.props.organisation._id}</h4>
                         <strong>Modifier l'adresse d'un Organisme de Formation</strong>
                         <div>
-                            { this.props.organisation.editedEmail &&
-                                <Email label="Anotea" current={this.props.organisation.editedEmail} active={this.getEmail()} organisationId={this.props.organisation._id} />
+                            { (this.state.editedEmail || this.state.anoteaEmailmode) &&
+                                <Email label="Anotea" current={this.state.editedEmail} active={this.state.email} organisationId={this.props.organisation._id} deleteEditedEmail={this.deleteEditedEmail} updateEditedEmail={this.updateEditedEmail} mode={this.state.anoteaEmailmode} changeMode={this.changeMode} editButton={true} />
                             }
                             { this.props.organisation.meta.kairosData &&
-                                <Email label="Kairos" current={this.props.organisation.meta.kairosData.emailRGC} active={this.getEmail()} organisationId={this.props.organisation._id} />
+                                <Email label="Kairos" current={this.props.organisation.meta.kairosData.emailRGC} active={this.state.email} organisationId={this.props.organisation._id} changeMode={this.changeMode} editButton={this.state.anoteaEmailmode === 'view'} />
                             }
-                            <Email label="Intercarif" current={this.props.organisation.courriel} active={this.getEmail()} organisationId={this.props.organisation._id} />
+                            <Email label="Intercarif" current={this.props.organisation.courriel} active={this.state.email} organisationId={this.props.organisation._id} changeMode={this.changeMode} editButton={this.state.anoteaEmailmode === 'view'} />
                         </div>
                     </div>
                 }

--- a/backoffice/src/components/backoffice/moderation/OrganisationDetail.js
+++ b/backoffice/src/components/backoffice/moderation/OrganisationDetail.js
@@ -3,18 +3,11 @@ import PropTypes from 'prop-types';
 
 import './sideMenu.css';
 
-import { updateEditedEmail } from '../../../lib/organisationService';
+import Email from './Email';
+
 
 export default class OrganisationDetail extends React.PureComponent {
     //13000285000019
-    state = {
-        mode: 'view',
-        emailEdited: ''
-    }
-
-    propTypes = {
-        organisation: PropTypes.object.isRequired,
-    }
 
     getEmail = () => {
         let email = this.props.organisation.courriel;
@@ -28,22 +21,8 @@ export default class OrganisationDetail extends React.PureComponent {
         return email;
     }
 
-    changeMode = mode => {
-        this.setState({ mode: mode });
-    }
-
-    cancel = () => {
-        this.setState({ emailEdited: '' });
-        this.changeMode('view');
-    }
-
-    update = () => {
-        updateEditedEmail(this.props.organisation._id, this.state.emailEdited);
-        this.changeMode('view');
-    }
-
-    handleEmailChange = event => {
-        this.setState({ emailEdited: event.target.value });
+    static propTypes = {
+        organisation: PropTypes.object
     }
 
     render() {
@@ -60,17 +39,13 @@ export default class OrganisationDetail extends React.PureComponent {
                         <h4>SIRET {this.props.organisation._id}</h4>
                         <strong>Modifier l'adresse d'un Organisme de Formation</strong>
                         <div>
-                            Adresse email Anotea : 
-                            {this.state.mode === 'view' &&
-                                <div>
-                                    <span>{this.getEmail()}</span> <button className="btn btn-primary" onClick={this.changeMode.bind(this, 'edit')}>Modifier</button>
-                                </div>
+                            { this.props.organisation.editedEmail &&
+                                <Email label="Anotea" current={this.props.organisation.editedEmail} active={this.getEmail()} organisationId={this.props.organisation._id} />
                             }
-                            {this.state.mode === 'edit' &&
-                                <div>
-                                    <input type="text" value={this.state.editedEmail} onChange={this.handleEmailChange} /> <button className="btn btn-primary" onClick={this.update}>Mettre à jour</button> <button className="btn" onClick={this.cancel}>Annuler</button>
-                                </div>
+                            { this.props.organisation.meta.kairosData &&
+                                <Email label="Kairos" current={this.props.organisation.meta.kairosData.emailRGC} active={this.getEmail()} organisationId={this.props.organisation._id} />
                             }
+                            <Email label="Intercarif" current={this.props.organisation.courriel} active={this.getEmail()} organisationId={this.props.organisation._id} />
                         </div>
                     </div>
                 }

--- a/backoffice/src/components/backoffice/moderation/OrganisationDetail.js
+++ b/backoffice/src/components/backoffice/moderation/OrganisationDetail.js
@@ -3,8 +3,10 @@ import PropTypes from 'prop-types';
 
 import './sideMenu.css';
 
-export default class OrganisationDetail extends React.PureComponent {
+import { updateEditedEmail } from '../../../lib/organisationService';
 
+export default class OrganisationDetail extends React.PureComponent {
+    //13000285000019
     state = {
         mode: 'view',
         emailEdited: ''
@@ -12,10 +14,6 @@ export default class OrganisationDetail extends React.PureComponent {
 
     propTypes = {
         organisation: PropTypes.object.isRequired,
-    }
-
-    componentWillReceiveProps = async nextProps => {
-        console.log(nextProps)
     }
 
     getEmail = () => {
@@ -31,7 +29,7 @@ export default class OrganisationDetail extends React.PureComponent {
     }
 
     changeMode = mode => {
-        this.setState({mode : mode});
+        this.setState({ mode: mode });
     }
 
     cancel = () => {
@@ -40,9 +38,12 @@ export default class OrganisationDetail extends React.PureComponent {
     }
 
     update = () => {
-        // TODO : save
-        this.setState({ emailEdited: '' });
+        updateEditedEmail(this.props.organisation._id, this.state.emailEdited);
         this.changeMode('view');
+    }
+
+    handleEmailChange = event => {
+        this.setState({ emailEdited: event.target.value });
     }
 
     render() {
@@ -67,7 +68,7 @@ export default class OrganisationDetail extends React.PureComponent {
                             }
                             {this.state.mode === 'edit' &&
                                 <div>
-                                    <input type="text" /> <button className="btn btn-primary" onClick={this.update}>Mettre à jour</button> <button className="btn" onClick={this.cancel}>Annuler</button>
+                                    <input type="text" value={this.state.editedEmail} onChange={this.handleEmailChange} /> <button className="btn btn-primary" onClick={this.update}>Mettre à jour</button> <button className="btn" onClick={this.cancel}>Annuler</button>
                                 </div>
                             }
                         </div>

--- a/backoffice/src/components/backoffice/moderation/OrganisationInfo.js
+++ b/backoffice/src/components/backoffice/moderation/OrganisationInfo.js
@@ -1,0 +1,24 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import moment from 'moment';
+
+
+export default class OrganisationInfo extends React.Component {
+
+    propTypes = {
+        organisation: PropTypes.object.isRequired
+    }
+
+    render() {
+        return (
+            <div className="organisationInfo">
+                <ul>
+                    <li>Email envoyé {moment(this.props.organisation.mailSentDate).fromNow()}</li>
+                    <li>Mot de passé créé : {this.props.organisation.passwordHash !== undefined ? 'oui' : 'non'}</li>
+                    <li>Avis : {this.props.organisation.advicesCount}</li>
+                </ul>
+            </div>
+        );
+    }
+}

--- a/backoffice/src/components/backoffice/moderation/OrganisationInfo.js
+++ b/backoffice/src/components/backoffice/moderation/OrganisationInfo.js
@@ -3,10 +3,9 @@ import PropTypes from 'prop-types';
 
 import moment from 'moment';
 
-
 export default class OrganisationInfo extends React.Component {
 
-    propTypes = {
+    static propTypes = {
         organisation: PropTypes.object.isRequired
     }
 
@@ -16,7 +15,7 @@ export default class OrganisationInfo extends React.Component {
                 <ul>
                     <li>Email envoyé {moment(this.props.organisation.mailSentDate).fromNow()}</li>
                     <li>Mot de passé créé : {this.props.organisation.passwordHash !== undefined ? 'oui' : 'non'}</li>
-                    <li>Avis : {this.props.organisation.advicesCount}</li>
+                    <li>{this.props.organisation.advicesCount} avis</li>
                 </ul>
             </div>
         );

--- a/backoffice/src/components/backoffice/moderation/OrganisationPanel.js
+++ b/backoffice/src/components/backoffice/moderation/OrganisationPanel.js
@@ -32,7 +32,7 @@ export default class OrganisationPanel extends React.PureComponent {
         return (
             <div className="organisationPanel">
                 <h1>Gestion des organismes</h1>
-                <input type="text" placeholder="SIRET" value={this.state.siret} onChange={this.updateSIRET} /> <button className="btn btn-primary" onClick={this.doSearch}>Chercher</button>
+                <input type="text" placeholder="SIRET" value={this.state.siret} onChange={this.updateSIRET} /> <button className="btn btn-primary" onClick={this.doSearch}><i className="glyphicon glyphicon-search"></i> Chercher</button>
 
                 <OrganisationDetail organisation={this.state.organisation} refresh={this.doSearch} />
             </div>

--- a/backoffice/src/components/backoffice/moderation/OrganisationPanel.js
+++ b/backoffice/src/components/backoffice/moderation/OrganisationPanel.js
@@ -5,14 +5,14 @@ import { getOrganisationInfo } from '../../../lib/organisationService';
 
 import OrganisationDetail from './OrganisationDetail';
 
-export default class SideMenu extends React.PureComponent {
+export default class OrganisationPanel extends React.PureComponent {
 
     state = {
         siret: '',
         organisation: undefined
     }
 
-    propTypes = {
+    static propTypes = {
         codeRegion: PropTypes.string.isRequired,
     }
 

--- a/backoffice/src/components/backoffice/moderation/OrganisationPanel.js
+++ b/backoffice/src/components/backoffice/moderation/OrganisationPanel.js
@@ -34,7 +34,7 @@ export default class OrganisationPanel extends React.PureComponent {
                 <h1>Gestion des organismes</h1>
                 <input type="text" placeholder="SIRET" value={this.state.siret} onChange={this.updateSIRET} /> <button className="btn btn-primary" onClick={this.doSearch}>Chercher</button>
 
-                <OrganisationDetail organisation={this.state.organisation} />
+                <OrganisationDetail organisation={this.state.organisation} refresh={this.doSearch} />
             </div>
         );
     }

--- a/backoffice/src/components/backoffice/moderation/OrganisationPanel.js
+++ b/backoffice/src/components/backoffice/moderation/OrganisationPanel.js
@@ -1,0 +1,41 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import { getOrganisationInfo } from '../../../lib/organisationService';
+
+import OrganisationDetail from './OrganisationDetail';
+
+export default class SideMenu extends React.PureComponent {
+
+    state = {
+        siret: '',
+        organisation: undefined
+    }
+
+    propTypes = {
+        codeRegion: PropTypes.string.isRequired,
+    }
+
+    doSearch = () => {
+        getOrganisationInfo(this.state.siret).then(organisation => {
+            this.setState({ organisation: organisation });
+        }).catch(() => {
+            this.setState({ organisation: null });
+        });
+    }
+
+    updateSIRET = event => {
+        this.setState({ siret: event.target.value });
+    }
+
+    render() {
+        return (
+            <div className="organisationPanel">
+                <h1>Gestion des organismes</h1>
+                <input type="text" placeholder="SIRET" value={this.state.siret} onChange={this.updateSIRET} /> <button className="btn btn-primary" onClick={this.doSearch}>Chercher</button>
+
+                <OrganisationDetail organisation={this.state.organisation} />
+            </div>
+        );
+    }
+}

--- a/backoffice/src/components/backoffice/moderation/SideMenu.js
+++ b/backoffice/src/components/backoffice/moderation/SideMenu.js
@@ -10,7 +10,8 @@ export default class SideMenu extends React.PureComponent {
     }
 
     static propTypes = {
-        onChangePage: PropTypes.func.isRequired
+        onChangePage: PropTypes.func.isRequired,
+        features: PropTypes.array.isRequired
     }
 
     changePage = page => {
@@ -30,9 +31,11 @@ export default class SideMenu extends React.PureComponent {
                         <li>
                             <button className={this.state.currentPage === 'moderation' ? 'active' : ''} onClick={this.changePage.bind(this, 'moderation')}>Modération des avis</button>
                         </li>
-                        <li>
-                            <button className={this.state.currentPage === 'organisme' ? 'active' : ''} onClick={this.changePage.bind(this, 'organisme')}>Gestion des organismes</button>
-                        </li>
+                        { this.props.features.includes('EDIT_ORGANISATIONS') &&
+                            <li>
+                                <button className={this.state.currentPage === 'organisme' ? 'active' : ''} onClick={this.changePage.bind(this, 'organisme')}>Gestion des organismes</button>
+                            </li>
+                        }
                     </ul>
                 </div>
             </div>

--- a/backoffice/src/components/backoffice/moderation/SideMenu.js
+++ b/backoffice/src/components/backoffice/moderation/SideMenu.js
@@ -5,12 +5,12 @@ import './sideMenu.css';
 
 export default class SideMenu extends React.PureComponent {
 
-    propTypes = {
-        onChangePage: PropTypes.func.isRequired
-    }
-
     state = {
         currentPage: 'moderation'
+    }
+
+    static propTypes = {
+        onChangePage: PropTypes.func.isRequired
     }
 
     changePage = page => {
@@ -23,10 +23,10 @@ export default class SideMenu extends React.PureComponent {
             <div className="sideMenu">
                 <ul>
                     <li>
-                        <a className={this.state.currentPage === 'moderation' ? 'active' : ''} onClick={this.changePage.bind(this, 'moderation')}>Modération des avis</a>
+                        <button className={this.state.currentPage === 'moderation' ? 'active' : ''} onClick={this.changePage.bind(this, 'moderation')}>Modération des avis</button>
                     </li>
                     <li>
-                        <a className={this.state.currentPage === 'organisme' ? 'active' : ''} onClick={this.changePage.bind(this, 'organisme')}>Gestion des organismes</a>
+                        <button className={this.state.currentPage === 'organisme' ? 'active' : ''} onClick={this.changePage.bind(this, 'organisme')}>Gestion des organismes</button>
                     </li>
                 </ul>
             </div>

--- a/backoffice/src/components/backoffice/moderation/SideMenu.js
+++ b/backoffice/src/components/backoffice/moderation/SideMenu.js
@@ -1,0 +1,35 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import './sideMenu.css';
+
+export default class SideMenu extends React.PureComponent {
+
+    propTypes = {
+        onChangePage: PropTypes.func.isRequired
+    }
+
+    state = {
+        currentPage: 'moderation'
+    }
+
+    changePage = page => {
+        this.setState({ currentPage: page });
+        this.props.onChangePage(page);
+    }
+
+    render() {
+        return (
+            <div className="sideMenu">
+                <ul>
+                    <li>
+                        <a className={this.state.currentPage === 'moderation' ? 'active' : ''} onClick={this.changePage.bind(this, 'moderation')}>Modération des avis</a>
+                    </li>
+                    <li>
+                        <a className={this.state.currentPage === 'organisme' ? 'active' : ''} onClick={this.changePage.bind(this, 'organisme')}>Gestion des organismes</a>
+                    </li>
+                </ul>
+            </div>
+        );
+    }
+}

--- a/backoffice/src/components/backoffice/moderation/SideMenu.js
+++ b/backoffice/src/components/backoffice/moderation/SideMenu.js
@@ -21,14 +21,20 @@ export default class SideMenu extends React.PureComponent {
     render() {
         return (
             <div className="sideMenu">
-                <ul>
-                    <li>
-                        <button className={this.state.currentPage === 'moderation' ? 'active' : ''} onClick={this.changePage.bind(this, 'moderation')}>Modération des avis</button>
-                    </li>
-                    <li>
-                        <button className={this.state.currentPage === 'organisme' ? 'active' : ''} onClick={this.changePage.bind(this, 'organisme')}>Gestion des organismes</button>
-                    </li>
-                </ul>
+                <div className="dropdown">
+                    <button className="btn btn-default dropdown-toggle" type="button" data-toggle="dropdown">
+                        Menu
+                        <span className="caret"></span>
+                    </button>
+                    <ul className="dropdown-menu">
+                        <li>
+                            <button className={this.state.currentPage === 'moderation' ? 'active' : ''} onClick={this.changePage.bind(this, 'moderation')}>Modération des avis</button>
+                        </li>
+                        <li>
+                            <button className={this.state.currentPage === 'organisme' ? 'active' : ''} onClick={this.changePage.bind(this, 'organisme')}>Gestion des organismes</button>
+                        </li>
+                    </ul>
+                </div>
             </div>
         );
     }

--- a/backoffice/src/components/backoffice/moderation/email.css
+++ b/backoffice/src/components/backoffice/moderation/email.css
@@ -10,3 +10,7 @@
 .email.not-current .icon {
     display: none;
 }
+
+.email.not-current.anoteaEmail .view {
+    display: none;
+}

--- a/backoffice/src/components/backoffice/moderation/email.css
+++ b/backoffice/src/components/backoffice/moderation/email.css
@@ -1,7 +1,3 @@
-.email.current {
-    font-weight: bold;
-}
-
 .email.not-current {
     font-style: italic;
     color: #888;
@@ -13,4 +9,12 @@
 
 .email.not-current.anoteaEmail .view {
     display: none;
+}
+
+.email.active {
+    font-weight: bold;
+}
+
+.email .btn {
+    margin: 10px;
 }

--- a/backoffice/src/components/backoffice/moderation/email.css
+++ b/backoffice/src/components/backoffice/moderation/email.css
@@ -1,0 +1,12 @@
+.email.current {
+    font-weight: bold;
+}
+
+.email.not-current {
+    font-style: italic;
+    color: #888;
+}
+
+.email.not-current .icon {
+    display: none;
+}

--- a/backoffice/src/components/backoffice/moderation/organisationDetail.css
+++ b/backoffice/src/components/backoffice/moderation/organisationDetail.css
@@ -1,0 +1,3 @@
+.organisationDetail .not-found {
+    margin-top: 20px;
+}

--- a/backoffice/src/components/backoffice/moderation/sideMenu.css
+++ b/backoffice/src/components/backoffice/moderation/sideMenu.css
@@ -1,0 +1,22 @@
+.sideMenu {
+    height: 100%;
+    background-color: #F0F0F0;
+    display: inline-block;
+    padding: 0px 20px;
+}
+
+.sideMenu ul {
+    padding: 0;
+}
+
+.sideMenu ul li {
+    list-style: none;
+}
+
+.sideMenu a {
+    cursor: pointer;
+}
+
+.sideMenu a.active {
+    font-weight: bold;
+}

--- a/backoffice/src/components/backoffice/moderation/sideMenu.css
+++ b/backoffice/src/components/backoffice/moderation/sideMenu.css
@@ -1,8 +1,7 @@
 .sideMenu {
     height: 100%;
-    background-color: #F0F0F0;
     display: inline-block;
-    padding: 0px 20px;
+    padding: 20px 0px;
 }
 
 .sideMenu ul {
@@ -19,4 +18,22 @@
 
 .sideMenu a.active {
     font-weight: bold;
+}
+
+.sideMenu .dropdown {
+    background-color: #DEDEDE;
+    border-radius: 5px;
+}
+
+.sideMenu .dropdown-toggle .caret {
+    margin-left: 5px;
+}
+
+.sideMenu button {
+    border: none;
+    background: none;
+    width: 200px;
+    display: block;
+    text-align: left;
+    padding: 10px;
 }

--- a/backoffice/src/components/login/LoginForm.js
+++ b/backoffice/src/components/login/LoginForm.js
@@ -1,10 +1,17 @@
 import React from 'react';
 
+import PropTypes from 'prop-types';
+
 import { login } from '../../lib/loginService';
 
 export class LoginForm extends React.Component {
 
     state = {}
+
+    static propTypes = {
+        handleLoggedIn: PropTypes.func.isRequired,
+        handleForgottenPassword: PropTypes.func.isRequired
+    }
 
     constructor(props) {
         super(props);
@@ -38,8 +45,7 @@ export class LoginForm extends React.Component {
             this.setState({ errorLogin: false, loggedIn: true });
             this.handleLoggedIn(result);
         })
-        .catch(err => {
-            console.error(err);
+        .catch(() => {
             this.setState({ errorLogin: true });
         });
     }

--- a/backoffice/src/components/login/LoginWithAccessToken.js
+++ b/backoffice/src/components/login/LoginWithAccessToken.js
@@ -1,17 +1,25 @@
 import React from 'react';
 
+import PropTypes from 'prop-types';
+
 import { loginWithAccessToken } from '../../lib/loginService';
 
 export class LoginWithAccessToken extends React.Component {
 
     state = {
-        message: 'Connexion en cours..'
+        message: 'Connexion en cours...'
     };
+
+    static propTypes = {
+        handleLoggedIn: PropTypes.func.isRequired,
+        handleLogout: PropTypes.func.isRequired,
+        access_token: PropTypes.string.isRequired
+    }
 
     componentDidMount() {
         loginWithAccessToken(this.props.access_token)
         .then(result => this.props.handleLoggedIn(result))
-        .catch(err => {
+        .catch(() => {
             this.props.handleLogout();
         });
     }

--- a/backoffice/src/components/login/forgottenPassword.js
+++ b/backoffice/src/components/login/forgottenPassword.js
@@ -1,5 +1,7 @@
 import React from 'react';
 
+import PropTypes from 'prop-types';
+
 import { askNewPassword, updatePassword, checkIfPasswordTokenExists } from '../../lib/forgottenPasswordService';
 import { isPasswordStrongEnough, checkConfirm, passwordIsOK } from '../../utils/validation';
 
@@ -8,6 +10,13 @@ export class ForgottenPassword extends React.Component {
     state = {
         error: false,
         asked: false
+    }
+
+    static propTypes = {
+        onSuccess: PropTypes.func.isRequired,
+        onError: PropTypes.func.isRequired,
+        passwordLost: PropTypes.bool.isRequired,
+        token: PropTypes.string.isRequired
     }
 
     constructor(props) {

--- a/backoffice/src/lib/organisationService.js
+++ b/backoffice/src/lib/organisationService.js
@@ -59,3 +59,7 @@ export const updateEditedEmail = (id, email) => {
 export const deleteEditedEmail = (id, email) => {
     return _get(`/backoffice/organisation/${id}/editedEmail/delete`, { email: email });
 };
+
+export const resendEmailAccount = id => {
+    return _post(`/backoffice/organisation/${id}/resendEmailAccount`);
+};

--- a/backoffice/src/lib/organisationService.js
+++ b/backoffice/src/lib/organisationService.js
@@ -55,3 +55,7 @@ export const getOrganisationStates = id => {
 export const updateEditedEmail = (id, email) => {
     return _post(`/backoffice/organisation/${id}/editedEmail`, { email: email });
 };
+
+export const deleteEditedEmail = (id, email) => {
+    return _get(`/backoffice/organisation/${id}/editedEmail/delete`, { email: email });
+};

--- a/backoffice/src/lib/organisationService.js
+++ b/backoffice/src/lib/organisationService.js
@@ -51,3 +51,7 @@ export const loadInventory = (id, trainingId, postalCode) => {
 export const getOrganisationStates = id => {
     return _get(`/backoffice/organisation/${id}/states`);
 };
+
+export const updateEditedEmail = (id, email) => {
+    return _post(`/backoffice/organisation/${id}/editedEmail`, { email: email });
+};

--- a/backoffice/src/registerServiceWorker.js
+++ b/backoffice/src/registerServiceWorker.js
@@ -9,6 +9,7 @@
 // This link also includes instructions on opting out of this behavior.
 
 const isLocalhost = Boolean(
+    window.location.hostname === 'anotea.local' ||
     window.location.hostname === 'localhost' ||
     // [::1] is the IPv6 localhost address.
     window.location.hostname === '[::1]' ||

--- a/backoffice/src/utils/moment-fr.js
+++ b/backoffice/src/utils/moment-fr.js
@@ -1,0 +1,62 @@
+import moment from 'moment';
+
+moment.locale('fr', {
+    months : 'janvier_février_mars_avril_mai_juin_juillet_août_septembre_octobre_novembre_décembre'.split('_'),
+    monthsShort : 'janv._févr._mars_avr._mai_juin_juil._août_sept._oct._nov._déc.'.split('_'),
+    monthsParseExact : true,
+    weekdays : 'dimanche_lundi_mardi_mercredi_jeudi_vendredi_samedi'.split('_'),
+    weekdaysShort : 'dim._lun._mar._mer._jeu._ven._sam.'.split('_'),
+    weekdaysMin : 'Di_Lu_Ma_Me_Je_Ve_Sa'.split('_'),
+    weekdaysParseExact : true,
+    longDateFormat : {
+        LT : 'HH:mm',
+        LTS : 'HH:mm:ss',
+        L : 'DD/MM/YYYY',
+        LL : 'D MMMM YYYY',
+        LLL : 'D MMMM YYYY HH:mm',
+        LLLL : 'dddd D MMMM YYYY HH:mm'
+    },
+    calendar : {
+        sameDay : '[Aujourd’hui à] LT',
+        nextDay : '[Demain à] LT',
+        nextWeek : 'dddd [à] LT',
+        lastDay : '[Hier à] LT',
+        lastWeek : 'dddd [dernier à] LT',
+        sameElse : 'L'
+    },
+    relativeTime : {
+        future : 'dans %s',
+        past : 'il y a %s',
+        s : 'quelques secondes',
+        m : 'une minute',
+        mm : '%d minutes',
+        h : 'une heure',
+        hh : '%d heures',
+        d : 'un jour',
+        dd : '%d jours',
+        M : 'un mois',
+        MM : '%d mois',
+        y : 'un an',
+        yy : '%d ans'
+    },
+    dayOfMonthOrdinalParse : /\d{1,2}(er|e)/,
+    ordinal : function (number) {
+        return number + (number === 1 ? 'er' : 'e');
+    },
+    meridiemParse : /PD|MD/,
+    isPM : function (input) {
+        return input.charAt(0) === 'M';
+    },
+    // In case the meridiem units are not separated around 12, then implement
+    // this function (look at locale/id.js for an example).
+    // meridiemHour : function (hour, meridiem) {
+    //     return /* 0-23 hour, given meridiem token and hour 1-12 */ ;
+    // },
+    meridiem : function (hours, minutes, isLower) {
+        return hours < 12 ? 'PD' : 'MD';
+    },
+    week : {
+        dow : 1, // Monday is the first day of the week.
+        doy : 4  // The week that contains Jan 4th is the first week of the year.
+    }
+});


### PR DESCRIPTION
- Menu to switch betwin advice moderation and organisation management
- Search organisation
- Show basic information (SIRET, name, advice count...)
- A button to resend account creation email
- Show every known email addresses (anotea, kairos, intercarif)
- Allow to edit email used for contacting organisation 

This feature can be enabled for specific users throw `features` field in `moderator` collection.
Actions are logged in the `events` collection.

![capture du 2018-11-13 10-52-38](https://user-images.githubusercontent.com/55890/48406888-e53c0900-e735-11e8-9a42-4f97f0669d53.png)
