### PR TITLE
Fix backoffice advice rates

### DIFF
--- a/backoffice/src/components/backoffice/common/adviceRates.js
+++ b/backoffice/src/components/backoffice/common/adviceRates.js
@@ -1,16 +1,28 @@
 import React from 'react';
 
+import PropTypes from 'prop-types';
+
 import { Stars } from './Stars';
 
 export default class AdviceRates extends React.Component {
 
     state = {};
 
+    static propTypes = {
+        rates: PropTypes.object.isRequired
+    }
+
     constructor(props) {
         super(props);
         this.state = {
             rates: props.rates,
         };
+    }
+
+    componentWillReceiveProps(nextProps) {
+        if (nextProps.rates) {
+            this.setState({ rates: nextProps.rates });
+        }
     }
 
     render() {


### PR DESCRIPTION
Previously when switching tabs on backoffice, advices rates didn't update.
This PR fix this problem.