### PR TITLE
Fix edited courriel

### DIFF
--- a/backend/jobs/import/edited-emails/importer.js
+++ b/backend/jobs/import/edited-emails/importer.js
@@ -7,7 +7,7 @@ module.exports = function(db, logger, configuration) {
     const parse = require('csv-parse');
     const transform = require('stream-transform');
 
-    const importEditedEmail = file => {
+    const importEditedCourriel = file => {
         logger.info('Organisation edited email import - launch');
 
         let mailer = require('../../../components/mailer.js')(db, logger, configuration);
@@ -44,6 +44,6 @@ module.exports = function(db, logger, configuration) {
     };
 
     return {
-        importEditedEmail: importEditedEmail
+        importEditedCourriel: importEditedCourriel
     };
 };

--- a/backend/jobs/import/edited-emails/index.js
+++ b/backend/jobs/import/edited-emails/index.js
@@ -16,7 +16,7 @@ const main = async () => {
     let client = await getMongoClient(configuration.mongodb.uri);
     let logger = getLogger('anotea-job-edited-email-import', configuration);
     let db = client.db();
-    let editedEmailImporter = require(`./importer`)(db, logger, configuration);
+    let editedCourrielImporter = require(`./importer`)(db, logger, configuration);
 
     const abort = message => {
         logger.error(message, () => {
@@ -29,7 +29,7 @@ const main = async () => {
     }
 
     try {
-        editedEmailImporter.importEditedEmail(cli.file);
+        editedCourrielImporter.importEditedCourriel(cli.file);
     } catch (e) {
         abort(e);
     }

--- a/backend/routes/backoffice/organisations.js
+++ b/backend/routes/backoffice/organisations.js
@@ -429,7 +429,7 @@ module.exports = (db, authService, logger, configuration) => {
         }
     });
 
-    router.post('/backoffice/organisation/:id/editedEmail', checkAuth, tryAndCatch(async (req, res) => {
+    router.post('/backoffice/organisation/:id/editedCourriel', checkAuth, tryAndCatch(async (req, res) => {
         const email = req.body.email;
         const id = parseInt(req.params.id);
 
@@ -439,7 +439,7 @@ module.exports = (db, authService, logger, configuration) => {
 
         let organisme = await db.collection('organismes').findOne({ _id: id });
         if (organisme) {
-            await db.collection('organismes').update({ _id: id }, { $set: { editedEmail: email } });
+            await db.collection('organismes').update({ _id: id }, { $set: { editedCourriel: email } });
             saveEvent(id, 'editEmail', {
                 app: 'moderation',
                 profile: 'moderateur',
@@ -452,7 +452,7 @@ module.exports = (db, authService, logger, configuration) => {
         }
     }));
 
-    router.delete('/backoffice/organisation/:id/editedEmail', checkAuth, tryAndCatch(async (req, res) => {
+    router.delete('/backoffice/organisation/:id/editedCourriel', checkAuth, tryAndCatch(async (req, res) => {
         const id = parseInt(req.params.id);
 
         if (isNaN(id)) {
@@ -461,7 +461,7 @@ module.exports = (db, authService, logger, configuration) => {
 
         let organisme = await db.collection('organismes').findOne({ _id: id });
         if (organisme) {
-            await db.collection('organismes').update({ _id: id }, { $unset: { editedEmail: '' } });
+            await db.collection('organismes').update({ _id: id }, { $unset: { editedCourriel: '' } });
             saveEvent(id, 'deleteEmail', {
                 app: 'moderation',
                 profile: 'moderateur',

--- a/backend/test/integration/routes/backoffice/organisation-test.js
+++ b/backend/test/integration/routes/backoffice/organisation-test.js
@@ -131,7 +131,7 @@ describe(__filename, withServer(({ startServer, insertIntoDatabase, getTestDatab
         }));
 
         let response = await request(app)
-        .post(`/api/backoffice/organisation/${id}/editedEmail`)
+        .post(`/api/backoffice/organisation/${id}/editedCourriel`)
         .set('authorization', `Bearer ${token}`)
         .send({ email: 'edited@pole-emploi.fr' });
 
@@ -140,7 +140,7 @@ describe(__filename, withServer(({ startServer, insertIntoDatabase, getTestDatab
 
         let db = await getTestDatabase();
         let res = await db.collection('organismes').findOne({ _id: id });
-        assert.deepEqual(res.editedEmail, 'edited@pole-emploi.fr');
+        assert.deepEqual(res.editedCourriel, 'edited@pole-emploi.fr');
     });
 
     it('can delete an edited email', async () => {
@@ -152,14 +152,14 @@ describe(__filename, withServer(({ startServer, insertIntoDatabase, getTestDatab
         await insertIntoDatabase('organismes', newOrganismeAccount({
             _id: id,
             SIRET: id,
-            editedEmail: 'edited@pole-emploi.fr',
+            editedCourriel: 'edited@pole-emploi.fr',
             meta: {
                 siretAsString: '11111111111111'
             },
         }));
 
         let response = await request(app)
-        .delete(`/api/backoffice/organisation/${id}/editedEmail`)
+        .delete(`/api/backoffice/organisation/${id}/editedCourriel`)
         .set('authorization', `Bearer ${token}`);
 
         assert.equal(response.statusCode, 200);
@@ -167,6 +167,6 @@ describe(__filename, withServer(({ startServer, insertIntoDatabase, getTestDatab
 
         let db = await getTestDatabase();
         let res = await db.collection('organismes').findOne({ _id: id });
-        assert.ok(!res.editedEmail);
+        assert.ok(!res.editedCourriel);
     });
 }));

--- a/backoffice/src/components/backoffice/moderation/Email.js
+++ b/backoffice/src/components/backoffice/moderation/Email.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 
 import './email.css';
 
-import { updateEditedEmail, deleteEditedEmail } from '../../../lib/organisationService';
+import { updateEditedCourriel, deleteEditedCourriel } from '../../../lib/organisationService';
 
 export default class Email extends React.Component {
 
@@ -18,8 +18,8 @@ export default class Email extends React.Component {
         active: PropTypes.any.isRequired,
         label: PropTypes.string.isRequired,
         organisationId: PropTypes.number.isRequired,
-        deleteEditedEmail: PropTypes.func,
-        updateEditedEmail: PropTypes.func,
+        deleteEditedCourriel: PropTypes.func,
+        updateEditedCourriel: PropTypes.func,
         changeMode: PropTypes.func.isRequired,
         mode: PropTypes.string,
         editButton: PropTypes.bool.isRequired
@@ -48,15 +48,15 @@ export default class Email extends React.Component {
     }
 
     update = () => {
-        updateEditedEmail(this.props.organisationId, this.state.emailEdited).then(() => {
+        updateEditedCourriel(this.props.organisationId, this.state.emailEdited).then(() => {
             this.props.changeMode('view');
-            this.props.updateEditedEmail(this.state.emailEdited);
+            this.props.updateEditedCourriel(this.state.emailEdited);
         });
     }
 
     delete = () => {
-        deleteEditedEmail(this.props.organisationId).then(() => {
-            this.props.deleteEditedEmail();
+        deleteEditedCourriel(this.props.organisationId).then(() => {
+            this.props.deleteEditedCourriel();
         });
     }
 
@@ -66,7 +66,7 @@ export default class Email extends React.Component {
 
     render() {
         return (
-            <div className={`email ${this.state.active ? 'active' : 'not-current'} ${this.props.deleteEditedEmail ? 'anoteaEmail' : ''}`}>
+            <div className={`email ${this.state.active ? 'active' : 'not-current'} ${this.props.deleteEditedCourriel ? 'anoteaEmail' : ''}`}>
 
                 {this.state.mode === 'view' &&
                     <div className="view">
@@ -78,7 +78,7 @@ export default class Email extends React.Component {
                             </button>
                         }
 
-                        {this.props.deleteEditedEmail &&
+                        {this.props.deleteEditedCourriel &&
                             <button className="btn btn-danger" onClick={this.delete}>
                                 <span className="fas fa-trash"></span> Supprimer
                             </button>
@@ -88,7 +88,7 @@ export default class Email extends React.Component {
 
                 {this.state.mode === 'edit' &&
                     <div className="edit">
-                        Anotea : <input type="text" value={this.state.editedEmail} onChange={this.handleEmailChange} /> <button className="btn btn-primary" onClick={this.update}> <span className="fas fa-check"></span> Mettre à jour</button> <button className="btn" onClick={this.cancel}>Annuler</button>
+                        Anotea : <input type="text" value={this.state.editedCourriel} onChange={this.handleEmailChange} /> <button className="btn btn-primary" onClick={this.update}> <span className="fas fa-check"></span> Mettre à jour</button> <button className="btn" onClick={this.cancel}>Annuler</button>
                     </div>
                 }
             </div>

--- a/backoffice/src/components/backoffice/moderation/OrganisationDetail.js
+++ b/backoffice/src/components/backoffice/moderation/OrganisationDetail.js
@@ -18,14 +18,14 @@ export default class OrganisationDetail extends React.PureComponent {
         } catch (e) {
 
         }
-        email = this.state.editedEmail !== undefined ? this.state.editedEmail : email;
+        email = this.state.editedCourriel !== undefined ? this.state.editedCourriel : email;
 
         return email;
     }
 
     state = {
         email: null,
-        editedEmail: null,
+        editedCourriel: null,
         anoteaEmailmode: 'view',
         resendDisabled: false,
         lastResend: null,
@@ -42,7 +42,7 @@ export default class OrganisationDetail extends React.PureComponent {
         if (props.organisation !== undefined) {
             this.state.organisation = props.organisation;
             if (props.organisation !== null) {
-                this.state.editedEmail = props.organisation.editedEmail;
+                this.state.editedCourriel = props.organisation.editedCourriel;
                 this.state.email = this.getEmail();
             }
         }
@@ -54,7 +54,7 @@ export default class OrganisationDetail extends React.PureComponent {
             this.setState({ organisation: nextProps.organisation });
             if (nextProps.organisation !== null) {
                 this.setState({
-                    editedEmail: nextProps.organisation.editedEmail,
+                    editedCourriel: nextProps.organisation.editedCourriel,
                     organisation: nextProps.organisation
                 },
                 () => this.setState({
@@ -64,12 +64,12 @@ export default class OrganisationDetail extends React.PureComponent {
         }
     }
 
-    deleteEditedEmail = () => {
-        this.setState({ editedEmail: undefined }, () => this.setState({ email: this.getEmail() }));
+    deleteEditedCourriel = () => {
+        this.setState({ editedCourriel: undefined }, () => this.setState({ email: this.getEmail() }));
     }
 
-    updateEditedEmail = email => {
-        this.setState({ editedEmail: email, successShown: true }, () => this.setState({ email: this.getEmail() }));
+    updateEditedCourriel = email => {
+        this.setState({ editedCourriel: email, successShown: true }, () => this.setState({ email: this.getEmail() }));
         setTimeout(() => {
             this.setState({ successShown: false });
         }, 3000);
@@ -115,16 +115,16 @@ export default class OrganisationDetail extends React.PureComponent {
                         </div>
 
                         <div>
-                            { (this.state.editedEmail || this.state.anoteaEmailmode) &&
-                                <Email label="Anotea" current={this.state.editedEmail} active={this.state.email} organisationId={this.state.organisation._id} deleteEditedEmail={this.deleteEditedEmail} updateEditedEmail={this.updateEditedEmail} mode={this.state.anoteaEmailmode} changeMode={this.changeMode} editButton={true} />
+                            { (this.state.editedCourriel || this.state.anoteaEmailmode) &&
+                                <Email label="Anotea" current={this.state.editedCourriel} active={this.state.email} organisationId={this.state.organisation._id} deleteEditedCourriel={this.deleteEditedCourriel} updateEditedCourriel={this.updateEditedCourriel} mode={this.state.anoteaEmailmode} changeMode={this.changeMode} editButton={true} />
                             }
-                            { (this.state.organisation.meta.kairosData && this.state.editedEmail) &&
+                            { (this.state.organisation.meta.kairosData && this.state.editedCourriel) &&
                                 <strong>Adresses inactives:</strong>
                             }
                             { this.state.organisation.meta.kairosData &&
                                 <Email label="Kairos" current={this.state.organisation.meta.kairosData.emailRGC} active={this.state.email} organisationId={this.state.organisation._id} changeMode={this.changeMode} editButton={this.state.anoteaEmailmode === 'view'} />
                             }
-                            { (this.state.organisation.meta.kairosData && !this.state.editedEmail || !this.state.organisation.meta.kairosData && this.state.editedEmail) &&
+                            { (this.state.organisation.meta.kairosData && !this.state.editedCourriel || !this.state.organisation.meta.kairosData && this.state.editedCourriel) &&
                                 <strong>Adresses inactives:</strong>
                             }
                             <Email label="Intercarif" current={this.state.organisation.courriel} active={this.state.email} organisationId={this.state.organisation._id} changeMode={this.changeMode} editButton={this.state.anoteaEmailmode === 'view'} />

--- a/backoffice/src/lib/organisationService.js
+++ b/backoffice/src/lib/organisationService.js
@@ -52,12 +52,12 @@ export const getOrganisationStates = id => {
     return _get(`/backoffice/organisation/${id}/states`);
 };
 
-export const updateEditedEmail = (id, email) => {
-    return _post(`/backoffice/organisation/${id}/editedEmail`, { email: email });
+export const updateEditedCourriel = (id, email) => {
+    return _post(`/backoffice/organisation/${id}/editedCourriel`, { email: email });
 };
 
-export const deleteEditedEmail = (id, email) => {
-    return _delete(`/backoffice/organisation/${id}/editedEmail`, { email: email });
+export const deleteEditedCourriel = (id, email) => {
+    return _delete(`/backoffice/organisation/${id}/editedCourriel`, { email: email });
 };
 
 export const resendEmailAccount = id => {


### PR DESCRIPTION
Il y a deux noms de champs en base editedCourriel et editedEmail.
Du coup le changement de l'email n'est pas pris en compte.

Cette PR renomme dans tous les fichiers editedEmail par editedCourriel.

Il faudra également jouer le requête suivante en production pour corriger les données :

```js
db.organismes.update({},{
    $rename: { 
        'editedEmail': 'editedCourriel',
    },
},{multi:true})
```