### PR TITLE
Use ephemeralForTest MongoDB engine on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ before_install:
 
 install:
   - docker-compose build
-  - docker-compose up -d backend
+  - docker-compose -f docker-compose.yml -f docker-compose.override.yml -f docker-compose.test.yml up -d backend
 
 script:
   - docker exec anotea_backend bash -c "npm run test:all"

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,0 +1,5 @@
+version: '3.3'
+services:
+
+  mongodb:
+    command: --storageEngine=ephemeralForTest --wiredTigerCacheSizeGB 1


### PR DESCRIPTION
This is faster because `ephemeralForTest` is an in memory engine