### PR TITLE
[WIP] Supprimer la possibilité de modifier le MDP dans le BO FI

### DIFF
--- a/backoffice/src/App.jsx
+++ b/backoffice/src/App.jsx
@@ -180,6 +180,7 @@ class App extends Component {
     };
 
     showBackofficePages = () => {
+        const { profile } = this.state;
 
         //Use new design
         if (this.state.profile === 'moderateur') {
@@ -212,9 +213,11 @@ class App extends Component {
                             <Redirect exact from="/" to="/admin" />
                         </Switch>
 
-                        <Route
-                            path="/mon-compte"
-                            render={props => (<MonComptePanel {...props} />)} />
+                        { profile === 'moderateur' || profile === 'organisme' &&
+                            <Route
+                                path="/mon-compte"
+                                render={props => (<MonComptePanel {...props} />)} />
+                        }
 
                         <Route
                             path="/admin"

--- a/backoffice/src/components/backoffice/common/deprecated/DeprecatedHeader.jsx
+++ b/backoffice/src/components/backoffice/common/deprecated/DeprecatedHeader.jsx
@@ -57,16 +57,6 @@ export default class DeprecatedHeader extends React.PureComponent {
 
                 {props.loggedIn &&
                     <div>
-                        <NavLink to="/mon-compte"
-                            className="account-link"
-                            activeClassName="active">
-                            {props.profile === 'organisme' &&
-                                <a className="helpLink"
-                                    href={`https://anotea.pole-emploi.fr/static/notices/notice-${props.codeRegion}.pdf`}>Aide&nbsp;&nbsp;
-                                </a>
-                            }
-                            <span className="fas fa-cog" />
-                        </NavLink>
                         <Logout handleLogout={props.handleLogout} />
                     </div>
                 }


### PR DESCRIPTION
- le compte étant partagé par plusieurs, le mdp ne doit pas pouvoir être modifié.
- J'ai supprimé aussi le bouton `aide` dans le BO organisme car il a le même comportement que le bouton `compte`. Aussi, un autre onlget existe pour afficher la page Aide.