### PR TITLE
Fix nbAvis stats

### DIFF
--- a/backend/src/jobs/data/migration/index.js
+++ b/backend/src/jobs/data/migration/index.js
@@ -15,5 +15,6 @@ execute(async ({ db, logger }) => {
     };
 
     return {
+        ...(await migrate('fixInvalidStats')),
     };
 });

--- a/backend/src/jobs/data/migration/tasks/fixInvalidStats.js
+++ b/backend/src/jobs/data/migration/tasks/fixInvalidStats.js
@@ -1,0 +1,10 @@
+const { getNbModifiedDocuments } = require('../../../job-utils');
+
+module.exports = async db => {
+
+    let res = await db.collection('statistics').updateMany({}, [
+        { '$set': { 'regions.11.avis.nbAvis': '$regions.11.api.nbAvis' } }
+    ]);
+
+    return { updated: getNbModifiedDocuments(res) };
+};


### PR DESCRIPTION
Une correction avait été réalisé fin février pour changer la manière dont on comptait les avis mais la migration des données n'avait visiblement pas été fait.

Ceci entraine une valeur invalide pour le mois de Mars
![image](https://user-images.githubusercontent.com/221211/79951080-5aa62000-8478-11ea-8c19-0b1365566b2e.png)

Cette PR corrige le nombre d'avis dans les statistiques "avis" en se basant sur la même information qui est stockée dans les statistiques "api".
